### PR TITLE
further upstream changes from jocalsend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,9 @@ use std::{
     collections::BTreeMap,
     fmt::Debug,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    path::PathBuf,
     sync::{Arc, OnceLock},
+    time::Duration,
 };
 
 pub use config::Config;
@@ -19,8 +21,8 @@ use models::{Device, FileMetadata};
 use tokio::{
     net::UdpSocket,
     sync::{
-        mpsc::{self, UnboundedSender},
-        Mutex,
+        RwLock,
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
     },
     task::JoinSet,
 };
@@ -28,16 +30,17 @@ use transfer::Session;
 
 pub const DEFAULT_PORT: u16 = 53317;
 pub const MULTICAST_IP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 167);
-pub const LISTENING_SOCKET_ADDR: SocketAddrV4 =
-    SocketAddrV4::new(Ipv4Addr::from_bits(0), DEFAULT_PORT);
+pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(100);
 
-pub type ShutdownSender = mpsc::Sender<()>;
+pub type Peers = Arc<RwLock<BTreeMap<String, (SocketAddr, Device)>>>;
+pub type Sessions = Arc<RwLock<BTreeMap<String, Session>>>; // Session ID to Session
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Listeners {
+pub enum LocalTask {
     Udp,
     Http,
     Multicast,
+    Tick,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,11 +49,22 @@ pub enum ReceiveDialog {
     Deny,
 }
 
-#[derive(Debug, Clone)]
-pub enum TransferEvent {
-    Received(Julid),
-    Cancelled(Julid),
+#[derive(Debug)]
+pub enum SendingType {
+    File(PathBuf),
+    Text(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalEvent {
+    ReceivedInbound(Julid),
+    SendApproved(String),
+    SendDenied,
+    SendSuccess { content: String, session: String },
+    SendFailed { error: String },
+    Cancelled { session_id: Julid },
     ReceiveRequest { id: Julid, request: ReceiveRequest },
+    Tick,
 }
 
 #[derive(Clone)]
@@ -59,6 +73,14 @@ pub struct ReceiveRequest {
     pub files: BTreeMap<String, FileMetadata>,
     pub tx: UnboundedSender<ReceiveDialog>,
 }
+
+impl PartialEq for ReceiveRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.alias == other.alias && self.files == other.files
+    }
+}
+
+impl Eq for ReceiveRequest {}
 
 impl Debug for ReceiveRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -69,107 +91,136 @@ impl Debug for ReceiveRequest {
     }
 }
 
+impl ReceiveRequest {
+    pub fn file_names(&self) -> Vec<String> {
+        self.files.values().map(|f| f.file_name.clone()).collect()
+    }
+}
+
 /// Contains the main network and backend state for an application session.
 #[derive(Clone)]
 pub struct LocalService {
-    pub peers: Arc<Mutex<BTreeMap<String, (SocketAddr, Device)>>>,
-    pub sessions: Arc<Mutex<BTreeMap<String, Session>>>, // Session ID to Session
-    pub running_state: Arc<Mutex<RunningState>>,
+    pub peers: Peers,
+    pub sessions: Sessions,
+    pub running_state: Arc<RwLock<RunningState>>,
     pub socket: Arc<UdpSocket>,
     pub client: reqwest::Client,
     pub config: Config,
-    shutdown_sender: OnceLock<ShutdownSender>,
+    pub http_handle: Arc<OnceLock<axum_server::Handle>>,
     // the receiving end will be held by the application so it can update the UI based on backend
     // events
-    transfer_event_tx: UnboundedSender<TransferEvent>,
+    transfer_event_tx: UnboundedSender<LocalEvent>,
 }
 
 impl LocalService {
     pub async fn new(
         config: Config,
-        transfer_event_tx: UnboundedSender<TransferEvent>,
-    ) -> crate::error::Result<Self> {
-        let socket = UdpSocket::bind(LISTENING_SOCKET_ADDR).await?;
-        socket.set_multicast_loop_v4(true)?;
-        socket.set_multicast_ttl_v4(8)?; // 8 hops out from localnet
-        socket.join_multicast_v4(MULTICAST_IP, Ipv4Addr::from_bits(0))?;
+    ) -> crate::error::Result<(Self, UnboundedReceiver<LocalEvent>)> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let addr = SocketAddrV4::new(config.local_ip_addr, DEFAULT_PORT);
+        let socket = UdpSocket::bind(addr).await?;
+        socket.set_multicast_loop_v4(false)?;
+        socket.set_multicast_ttl_v4(1)?; // local subnet only
+        socket.join_multicast_v4(MULTICAST_IP, *addr.ip())?;
 
         let client = reqwest::ClientBuilder::new()
             // localsend certs are self-signed
             .danger_accept_invalid_certs(true)
             .build()?;
 
-        Ok(Self {
-            config,
-            client,
-            socket: socket.into(),
-            transfer_event_tx,
-            peers: Default::default(),
-            sessions: Default::default(),
-            running_state: Default::default(),
-            shutdown_sender: Default::default(),
-        })
+        Ok((
+            Self {
+                config,
+                client,
+                socket: socket.into(),
+                transfer_event_tx: tx,
+                peers: Default::default(),
+                sessions: Default::default(),
+                running_state: Default::default(),
+                http_handle: Default::default(),
+            },
+            rx,
+        ))
     }
 
-    pub async fn start(&self, handles: &mut JoinSet<Listeners>) {
+    pub async fn start(&self) -> JoinSet<LocalTask> {
         let service = self.clone();
 
-        handles.spawn({
-            let (tx, shutdown_rx) = mpsc::channel(1);
-            let _ = self.shutdown_sender.set(tx);
-            async move {
-                if let Err(e) = service.start_http_server(shutdown_rx).await {
-                    error!("HTTP server error: {e}");
-                }
-                Listeners::Http
+        let mut handles = JoinSet::new();
+
+        handles.spawn(async move {
+            if let Err(e) = service.start_http_server().await {
+                error!("HTTP server error: {e}");
             }
+            LocalTask::Http
         });
         let service = self.clone();
 
-        handles.spawn({
-            async move {
-                if let Err(e) = service.listen_multicast().await {
-                    error!("UDP listener error: {e}");
-                }
-                Listeners::Multicast
+        handles.spawn(async move {
+            if let Err(e) = service.listen_multicast().await {
+                error!("UDP listener error: {e}");
             }
+            LocalTask::Multicast
         });
 
         let service = self.clone();
-        handles.spawn({
-            async move {
-                loop {
-                    let rstate = service.running_state.lock().await;
-                    if *rstate == RunningState::Stopping {
-                        break;
-                    }
-                    if let Err(e) = service.announce(None).await {
-                        error!("Announcement error: {e}");
-                    }
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        handles.spawn(async move {
+            let service = &service;
+            let mut tick = tokio::time::interval(DEFAULT_INTERVAL);
+
+            loop {
+                tick.tick().await;
+                service
+                    .transfer_event_tx
+                    .send(LocalEvent::Tick)
+                    .unwrap_or_else(|e| log::warn!("could not send tick event: {e:?}"));
+
+                let rstate = service.running_state.read().await;
+                if *rstate == RunningState::Stopping {
+                    break;
                 }
-                Listeners::Udp
             }
+            LocalTask::Tick
         });
+
+        let service = self.clone();
+        handles.spawn(async move {
+            loop {
+                if let Err(e) = service.announce(None).await {
+                    error!("Announcement error: {e}");
+                }
+
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
+                let rstate = service.running_state.read().await;
+                if *rstate == RunningState::Stopping {
+                    break;
+                }
+            }
+            LocalTask::Udp
+        });
+
+        handles
     }
 
     pub async fn stop(&self) {
-        let mut rstate = self.running_state.lock().await;
-        *rstate = RunningState::Stopping;
-        let _ = self
-            .shutdown_sender
+        {
+            let mut rstate = self.running_state.write().await;
+            *rstate = RunningState::Stopping;
+        }
+        log::info!("shutting down http server");
+        self.http_handle
             .get()
-            .expect("Could not get stop signal transmitter")
-            .send(())
-            .await;
+            .expect("missing http handle for shutdown")
+            .graceful_shutdown(Some(Duration::from_secs(5)));
     }
 
-    pub async fn refresh_peers(&self) {
-        let mut peers = self.peers.lock().await;
+    pub async fn clear_peers(&self) {
+        let mut peers = self.peers.write().await;
         peers.clear();
     }
 
-    pub fn send_event(&self, event: TransferEvent) {
+    pub fn send_event(&self, event: LocalEvent) {
         if let Err(e) = self.transfer_event_tx.send(event.clone()) {
             error!("got error sending transfer event '{event:?}': {e:?}");
         }

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::LocalSendError;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct FileMetadata {
     pub id: String,
@@ -21,7 +21,7 @@ pub struct FileMetadata {
     pub metadata: Option<FileMetadataExt>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileMetadataExt {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub modified: Option<String>,
@@ -81,7 +81,7 @@ impl FileMetadata {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DeviceType {
     Mobile,
@@ -109,6 +109,14 @@ pub struct Device {
     #[serde(default)]
     pub announce: Option<bool>,
 }
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.fingerprint == other.fingerprint
+    }
+}
+
+impl Eq for Device {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
More backend changes from [jocalsend](https://git.kittencollective.com/nebkor/joecalsend). Notable improvements:

 - actually support the `cancel` endpoint
 - don't block the main thread while waiting for an upload to be approved on the remote end (by launching a Tokio task)
 - don't multicast to yourself

For those last two, there's some exposition: https://proclamations.nebcorp-hias.com/rnd/jocalsend-development/#back-to-backend
